### PR TITLE
feat: CI-316 Add JWT parsing capability in tenant matcher middleware

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -592,7 +592,30 @@ as well as an optional minimal TLS version that is acceptable.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `Rules` | _[]*github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options.TenantMatcherRule_ |  |
+| `rules` | _[[]TenantMatcherRule](#tenantmatcherrule)_ | Rules define the rules for finding tenant id in the incoming request |
+
+### TenantMatcherRule
+
+(**Appears on:** [TenantMatcher](#tenantmatcher))
+
+TenantMatcherRule is the structure to define rule for finding tenant id in request
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `source` | _[TenantMatcherRuleSource](#tenantmatcherrulesource)_ | Source defines which part of the HTTP request contains the tenant id |
+| `expr` | _string_ | Expr defines the regex expression to match and extract tenant id from the source |
+| `captureGroup` | _int_ | CaptureGroup or sub-match referes to the index that is actually the tenant id |
+| `queryParam` | _string_ | QueryParam defines the query parameter containing tenant-id in case source is 'query' |
+| `header` | _string_ | Header defines the header key in case source is 'header' |
+| `jwtClaim` | _string_ | JWT Claim defines the json field containing tenant id in jwt token e.g tenant.id |
+
+### TenantMatcherRuleSource
+#### (`string` alias)
+
+(**Appears on:** [TenantMatcherRule](#tenantmatcherrule))
+
+Source defines the source i-e "host", "path", "query" or "header"
+
 
 ### URLParameterRule
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.8.1
+	github.com/tidwall/gjson v1.14.4
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/crypto v0.7.0
 	golang.org/x/exp v0.0.0-20230307190834-24139beb5833
@@ -82,6 +83,8 @@ require (
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,12 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=

--- a/pkg/apis/options/tenantMatcher.go
+++ b/pkg/apis/options/tenantMatcher.go
@@ -1,5 +1,6 @@
 package options
 
+// Source defines the source i-e "host", "path", "query" or "header"
 type TenantMatcherRuleSource string
 
 const (
@@ -9,24 +10,29 @@ const (
 	TenantMatcherRuleSourceHeader      TenantMatcherRuleSource = "header"
 )
 
+// TenantMatcherRule is the structure to define rule for finding tenant id in request
 type TenantMatcherRule struct {
 
 	// Source defines which part of the HTTP request contains the tenant id
-	Source TenantMatcherRuleSource
+	Source TenantMatcherRuleSource `json:"source,omitempty"`
 
 	// Expr defines the regex expression to match and extract tenant id from the source
-	Expr string
+	Expr string `json:"expr,omitempty"`
 
 	// CaptureGroup or sub-match referes to the index that is actually the tenant id
-	CaptureGroup int
+	CaptureGroup int `json:"captureGroup,omitempty"`
 
 	// QueryParam defines the query parameter containing tenant-id in case source is 'query'
-	QueryParam string
+	QueryParam string `json:"queryParam,omitempty"`
 
 	// Header defines the header key in case source is 'header'
-	Header string
+	Header string `json:"header,omitempty"`
+
+	// JWT Claim defines the json field containing tenant id in jwt token e.g tenant.id
+	JWTClaim string `json:"jwtClaim,omitempty"`
 }
 
 type TenantMatcher struct {
-	Rules []*TenantMatcherRule
+	// Rules define the rules for finding tenant id in the incoming request
+	Rules []TenantMatcherRule `json:"rules,omitempty"`
 }

--- a/pkg/middleware/tenantMatcher_test.go
+++ b/pkg/middleware/tenantMatcher_test.go
@@ -16,7 +16,7 @@ func TestTenantMatcher(t *testing.T) {
 
 	rw := httptest.NewRecorder()
 	tm, _ := tenantmatcher.New(options.TenantMatcher{
-		Rules: []*options.TenantMatcherRule{
+		Rules: []options.TenantMatcherRule{
 			{
 				Source:       options.TenantMatcherRuleSourceQueryParams,
 				QueryParam:   "tenantid",


### PR DESCRIPTION
Add JWT Parsing Capability in TenantMatcher Middleware
## Description

TenantMatcher config is modified to add a new field JWTClaim.
This allows to specify the field in JSON string containing tenant-id. 
The JWT token is found from the Authorization header using a regex.
Then it's decoded from Base64 into a JSON string.
Finally tenant id is extracted from JSON field specified. 

## Motivation and Context

This will allow requests with tokens to get authenticated. 

## How Has This Been Tested?

Unittests are modified to add this new scenario. 
All other tests are passing.

## Checklist:


- [x] I have created a feature (non-master) branch for my PR.
