### PR TITLE
fix: CI-313 add quotes around schema name

### DIFF
--- a/pkg/providerloader/postgres/postgres.go
+++ b/pkg/providerloader/postgres/postgres.go
@@ -20,7 +20,7 @@ type provider struct {
 }
 
 func runMigrations(db *gorm.DB, schema string) error {
-	res := db.Exec("create schema if not exists  " + schema)
+	res := db.Exec("create schema if not exists  " + "\"" + schema + "\"")
 	if res.Error != nil {
 		return res.Error
 	}


### PR DESCRIPTION
This is a bugfix where we were unable to create Postgres schema if the name contains a hyphen '-'

## Description

In order to fix this issue, quotes are added around the schema name in the exec command.

## Checklist:

- [x] I have created a feature (non-master) branch for my PR.
