### PR TITLE
feat: CI-335 add tenantid label in prometheus metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.8.1
 	github.com/tidwall/gjson v1.14.4
+	github.com/urfave/negroni v1.0.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/crypto v0.7.0
 	golang.org/x/exp v0.0.0-20230307190834-24139beb5833

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
+github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -319,10 +319,10 @@ func (p *OAuthProxy) buildServeMux(proxyPrefix string) {
 	// Otherwise something like /%2F/ would be redirected to / here already.
 	r := mux.NewRouter().UseEncodedPath()
 	// Everything served by the router must go through the preAuthChain first.
-	r.Use(p.preAuthChain.Then)
 
 	r.Use(p.tenantMatcherChain.Then)
 	r.Use(p.providerLoaderChain.Then)
+	r.Use(p.preAuthChain.Then)
 
 	// Register the robots path writer
 	r.Path(robotsPath).HandlerFunc(p.pageWriter.WriteRobotsTxt)

--- a/pkg/middleware/testdata/metrics/notfoundrequest.txt
+++ b/pkg/middleware/testdata/metrics/notfoundrequest.txt
@@ -1,3 +1,3 @@
 # HELP oauth2_proxy_requests_total Total number of requests by HTTP status code.
 # TYPE oauth2_proxy_requests_total counter
-oauth2_proxy_requests_total{code="404"} 1
+oauth2_proxy_requests_total{code="404",tenantid=""} 1

--- a/pkg/middleware/testdata/metrics/successfulrequest.txt
+++ b/pkg/middleware/testdata/metrics/successfulrequest.txt
@@ -1,3 +1,3 @@
 # HELP oauth2_proxy_requests_total Total number of requests by HTTP status code.
 # TYPE oauth2_proxy_requests_total counter
-oauth2_proxy_requests_total{code="200"} 1
+oauth2_proxy_requests_total{code="200",tenantid=""} 1


### PR DESCRIPTION
This pr includes adding tenantid labels in all prometheus metrics defined for oauth2-proxy 

## Description

The tenantid is extracted from query params and added to existing metrics along with other labels like code and method. 

## Motivation and Context

Adding tenantid label would allow to partition requests based on different tenants. 

## How Has This Been Tested?

Tests suits are modified accordingly. 

## Checklist:

- [x] I have created a feature (non-master) branch for my PR.
